### PR TITLE
docs: expand README with docker and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,26 @@ python cashsight/db/init_fake_db.py
 ```
 
 This will create `data/fake_cashsight.db` populated with the sample CSV data.
+
+### Run Postgres with Docker
+
+To spin up a local PostgreSQL instance and pgAdmin using Docker Compose, first
+update the connection settings in `.env` if needed. Then start the services:
+
+```bash
+docker compose up -d
+```
+
+Stop the containers when you are done:
+
+```bash
+docker compose down
+```
+
+### Run tests
+
+Use `pytest` to run the unit tests:
+
+```bash
+pytest
+```


### PR DESCRIPTION
## Summary
- document how to launch PostgreSQL and pgAdmin with Docker Compose
- note how to execute the test suite with `pytest`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689268ec729c832e83a548b041df0b55