### PR TITLE
Improve synthetic data generators and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python cashsight/db/init_fake_db.py
 
 This will create `data/fake_cashsight.db` populated with the sample CSV data.
 
-### Run Postgres with Docker
+### Run PostgreSQL with Docker
 
 To spin up a local PostgreSQL instance and pgAdmin using Docker Compose, first
 update the connection settings in `.env` if needed. Then start the services:

--- a/scripts/create_historical_data.py
+++ b/scripts/create_historical_data.py
@@ -24,7 +24,7 @@ def main():
     os.makedirs(hist_dir, exist_ok=True)
 
     user = generate_user()
-    vendors = generate_vendors(coa_df, user, num_vendors=60)
+    vendors = generate_vendors(user, num_vendors=60)
     units = generate_units(properties_df)
     tenants = generate_tenants(properties_df, units)
     leases = generate_leases(properties_df, tenants, units)

--- a/tests/test_daily_transactions.py
+++ b/tests/test_daily_transactions.py
@@ -32,6 +32,7 @@ def test_generate_vendor_invoices_count():
     ])
     inv = module.generate_vendor_invoices(vendors, properties, leases, module.coa_df, 1, 1)
     assert len(inv) == len(properties)
+    assert set(inv["property_id"]) == set(properties["property_id"])
 
 
 def test_generate_cust_invoices_matches_schedule():

--- a/tests/test_generate_user.py
+++ b/tests/test_generate_user.py
@@ -1,6 +1,7 @@
 import importlib.util
 import pandas as pd
 from pathlib import Path
+import pytest
 
 
 def load_module():
@@ -23,4 +24,10 @@ def test_generate_user_default_count_range():
     df = module.generate_user()
     assert 5 <= len(df) <= 10
     assert df['user_id'].is_unique
+
+
+def test_generate_user_negative_count():
+    module = load_module()
+    with pytest.raises(ValueError):
+        module.generate_user(count=-5)
 

--- a/tests/test_payment_schedule.py
+++ b/tests/test_payment_schedule.py
@@ -32,3 +32,29 @@ def test_generate_lease_pymnt_sched_length_and_proration():
     assert bool(sched.iloc[0]['is_prorated']) is True
     assert sched.iloc[0]['schd_dt'].month == 1
 
+
+def test_generate_lease_pymnt_sched_escalation():
+    module = load_module()
+    lease_start = pd.Timestamp('2023-01-01')
+    lease_end = pd.Timestamp('2025-12-31')
+    df = pd.DataFrame([
+        {
+            'id': 'L1',
+            'property_id': 'P1',
+            'unit_id': 'U1',
+            'tenant_id': 'T1',
+            'lease_start': lease_start,
+            'rent_start_date': lease_start,
+            'lease_end': lease_end,
+            'monthly_rent': 1000,
+            'pro_rated_start': False,
+            'payment_timing': 'In Advance',
+            'escalation_type': 'Fixed %',
+            'escalation_rate': 0.10,
+        }
+    ])
+    sched = module.generate_lease_pymnt_sched(df, months_out=25)
+    assert sched.iloc[0]['pymnt_amt'] == 1000
+    assert sched.iloc[12]['pymnt_amt'] == 1100
+    assert sched.iloc[24]['pymnt_amt'] == 1210
+


### PR DESCRIPTION
## Summary
- validate user counts and document generators
- fix vendor invoice property selection and add annual rent escalation
- add tests for user, vendor invoice, and payment schedule logic

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_689280a38cec832ea226c8e43ded5399