### PR TITLE
Fix compose configuration and requirements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
     ports:
-      - "54322:54322"
+      - "54322:5432"
     networks:
       - cashsight-net
     volumes:
@@ -46,8 +46,7 @@ services:
     ports:
       - "8081:8081"
     environment:
-      - |
-        FLINK_PROPERTIES=jobmanager.rpc.address: jobmanager
+      FLINK_PROPERTIES: "jobmanager.rpc.address: jobmanager"
     networks:
       - cashsight-net
 
@@ -57,8 +56,7 @@ services:
       - jobmanager
     command: taskmanager
     environment:
-      - |
-        FLINK_PROPERTIES=jobmanager.rpc.address: jobmanager
+      FLINK_PROPERTIES: "jobmanager.rpc.address: jobmanager"
     networks:
       - cashsight-net
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 pandas>=1.5.0
 openpyxl>=3.1.0
 faker>=15.3.4
+python-dateutil>=2.8.2
 sqlalchemy>=1.4
 psycopg2-binary>=2.9
 kafka-python>=2.0.2


### PR DESCRIPTION
## Summary
- correct Postgres port mapping and Flink job/task manager environment definitions in `docker-compose.yml`
- add missing `python-dateutil` dependency

## Testing
- `pip install pandas faker` *(failed: Could not find a version that satisfies the requirement pandas)*
- `docker-compose config` *(command not found)*
- `pytest -q` *(errors: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6892ae853144832e811f440d685360c8