### PR TITLE
Use Python 3.7 base image for Flink jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Stop the containers when you are done:
 docker compose down
 ```
 
+### Flink job image base
+
+The image built from `flink_jobs/Dockerfile` now relies on a multi-stage build
+that pulls Python 3.7 from the official `python:3.7-slim` image and combines it
+with the `flink:1.16.2` tooling. Ensure these base images are available locally
+when building the Flink job container.
+
 ### Run tests
 
 Use `pytest` to run the unit tests:

--- a/flink_jobs/Dockerfile
+++ b/flink_jobs/Dockerfile
@@ -1,38 +1,29 @@
+FROM --platform=linux/amd64 python:3.7-slim AS python
+
 FROM --platform=linux/amd64 flink:1.16.2
 
-# install python3: it has updated Python to 3.9 in Debian 11 and so install Python 3.7 from source
-# it currently only supports Python 3.6, 3.7 and 3.8 in PyFlink officially.
-RUN apt-get update -y && \
-apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev libffi-dev liblzma-dev && \
-wget https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz && \
-tar -xvf Python-3.7.9.tgz && \
-cd Python-3.7.9 && \
-./configure --without-tests --enable-shared && \
-make -j6 && \
-make install && \
-ldconfig /usr/local/lib && \
-cd .. && rm -f Python-3.7.9.tgz && rm -rf Python-3.7.9 && \
-ln -s /usr/local/bin/python3 /usr/local/bin/python && \
-apt-get clean && \
-rm -rf /var/lib/apt/lists/*
+# Copy Python runtime from the official Python 3.7 image
+COPY --from=python /usr/local /usr/local
+RUN ln -s /usr/local/bin/python3 /usr/local/bin/python
 
-# install PyFlink
+# Install PyFlink and other Python dependencies
 COPY requirements.txt .
-RUN python -m pip install --upgrade pip; \
-    pip3 install -r requirements.txt  --no-cache-dir;
+RUN python -m pip install --upgrade pip && \
+    pip install -r requirements.txt --no-cache-dir
 
-# Install Java 11
+# Install Java 11 and tools required for downloading connectors
 RUN apt-get update && \
-    apt-get install -y openjdk-11-jdk && \
-    apt-get clean;
+    apt-get install -y openjdk-11-jdk wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set environment variables
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
-
 # Download connector libraries
-RUN wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-python/1.16.2/flink-python-1.16.2.jar; \
-    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/1.16.2/flink-sql-connector-kafka-1.16.2.jar; \
-    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc/1.16.2/flink-connector-jdbc-1.16.2.jar; \
-    wget -P /opt/flink/lib/ https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.26/postgresql-42.2.26.jar;
+RUN wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-python/1.16.2/flink-python-1.16.2.jar && \
+    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/1.16.2/flink-sql-connector-kafka-1.16.2.jar && \
+    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc/1.16.2/flink-connector-jdbc-1.16.2.jar && \
+    wget -P /opt/flink/lib/ https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.26/postgresql-42.2.26.jar
+
 WORKDIR /opt/flink


### PR DESCRIPTION
## Summary
- avoid compiling Python from source by copying runtime from python:3.7-slim in a multi-stage Docker build
- document new base image requirements for the Flink job image

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas>=1.5.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68940bcd0654832eabd10a92b13a5a58