### PR TITLE
Remove quotes from POSTGRES_URL and document IP coding key

### DIFF
--- a/flink_jobs/flink-env.env
+++ b/flink_jobs/flink-env.env
@@ -1,8 +1,9 @@
+# API key for IP geolocation lookups; leave blank if not using
 IP_CODING_KEY=
 KAFKA_GROUP=web-events
 KAFKA_TOPIC=bootcamp-events-prod
 KAFKA_URL=kafka:9092
-POSTGRES_URL="jdbc:postgresql://cre-db:5432/postgres"
+POSTGRES_URL=jdbc:postgresql://cre-db:5432/postgres
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=postgres


### PR DESCRIPTION
## Summary
- document the optional IP_CODING_KEY and note when to set it
- remove extraneous quotes from POSTGRES_URL in Flink environment file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas due to 403 proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_68940bcb41c8832e89b793ca4c89aaa1