### PR TITLE
refactor: separate flink dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Install the required Python packages:
 pip install -r requirements.txt
 ```
 
+Flink and its Python dependencies are installed separately inside the
+Flink Docker image (see the `flink_jobs` directory) and therefore are
+not included in the main `requirements.txt`.
+
 ## Usage
 
 ### Generate sample data

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,5 @@ kafka-python>=2.0.2
 fastapi>=0.100.0
 uvicorn[standard]>=0.22.0
 requests>=2.31.0
-apache-flink==1.16.2
 pytest>=7.0.0
 


### PR DESCRIPTION
## Summary
- remove Apache Flink from root requirements so main environment installs cleanly
- clarify in README that PyFlink and connectors are installed via the Flink Docker image

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas>=1.5.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68940bcb10bc832e911166735f8e5a7a